### PR TITLE
fix:알림서버에 맞춰 구독 dto 수정 및 MQ 이름 변경

### DIFF
--- a/src/main/java/com/couponmoa/backend/couponmoastore/common/emailSender/dto/SendToMQDto.java
+++ b/src/main/java/com/couponmoa/backend/couponmoastore/common/emailSender/dto/SendToMQDto.java
@@ -10,15 +10,23 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class SendToMQDto {
-    private List<String> emailList;
-    private String subject;
-    private String text;
-    private String name;
+//    private List<String> emailList;coupon-create-queue
+//    private String subject;
+//    private String text;
+//    private String name;
+//
+//    public SendToMQDto(List<String> emailList, String subject, String name, String text) {
+//        this.emailList = emailList;
+//        this.subject = subject;
+//        this.name = name;
+//        this.text = text;
+//    }
 
-    public SendToMQDto(List<String> emailList, String subject, String name, String text) {
+    private String storeName;
+    private List<String> emailList;
+
+    public SendToMQDto(List<String> emailList, String storeName) {
         this.emailList = emailList;
-        this.subject = subject;
-        this.name = name;
-        this.text = text;
+        this.storeName = storeName;
     }
 }

--- a/src/main/java/com/couponmoa/backend/couponmoastore/common/emailSender/service/SqsService.java
+++ b/src/main/java/com/couponmoa/backend/couponmoastore/common/emailSender/service/SqsService.java
@@ -27,7 +27,7 @@ public class SqsService {
         try {
             log.info(">>> Sending message to SQS: {}", message);
             if (queueUrl == null) {
-                queueUrl = "couponmoa-queue";
+                queueUrl = "coupon-create-queue";
             }
             String messageQ = objectMapper.writeValueAsString(message);
             sqsTemplate.send(queueUrl, messageQ);
@@ -38,19 +38,19 @@ public class SqsService {
         }
     }
 
-    public void sendMessage(CouponAlertDto message) {
-        queueUrl = sqsProperties.getCouponAlert();
-        try {
-            log.info(">>> Sending coupon message to SQS: {}", message);
-            if (queueUrl == null) {
-                queueUrl = "coupon-alert";
-            }
-            String messageQ = objectMapper.writeValueAsString(message);
-            sqsTemplate.send(queueUrl, messageQ);
-            log.info(">>> Message sent successfully");
-        } catch (Exception e) {
-            log.error(">>> Failed to send message", e);
-            throw new ApplicationException(ErrorCode.UNABLE_SEND_MESSAGE);
-        }
-    }
+//    public void sendMessage(CouponAlertDto message) {
+//        queueUrl = sqsProperties.getCouponAlert();
+//        try {
+//            log.info(">>> Sending coupon message to SQS: {}", message);
+//            if (queueUrl == null) {
+//                queueUrl = "coupon-alert";
+//            }
+//            String messageQ = objectMapper.writeValueAsString(message);
+//            sqsTemplate.send(queueUrl, messageQ);
+//            log.info(">>> Message sent successfully");
+//        } catch (Exception e) {
+//            log.error(">>> Failed to send message", e);
+//            throw new ApplicationException(ErrorCode.UNABLE_SEND_MESSAGE);
+//        }
+//    }
 }

--- a/src/main/java/com/couponmoa/backend/couponmoastore/common/exception/ErrorCode.java
+++ b/src/main/java/com/couponmoa/backend/couponmoastore/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
     // subscribe
     DUPLICATED_USER_COUPON(CONFLICT, "이미 구독한 쿠폰입니다."),
+    DUPLICATED_USER_STORE(CONFLICT, "이미 구독한 가게입니다."),
     NO_SUBSCRIBER(NOT_FOUND, "구독한 유저가 없습니다."),
 
     // common

--- a/src/main/java/com/couponmoa/backend/couponmoastore/domain/store/controller/v2/StoreControllerV2.java
+++ b/src/main/java/com/couponmoa/backend/couponmoastore/domain/store/controller/v2/StoreControllerV2.java
@@ -29,7 +29,6 @@ public class StoreControllerV2 {
     public ResponseEntity<ApiResponse<StoreResponseDto>> createStore(
             @Valid @RequestBody StoreRequestDto request,
             @RequestHeader("X-User-Id") Long userId) {
-
         StoreResponseDto response = storeServiceV2.createStore(request, userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/service/UserStoreSubscribeService.java
+++ b/src/main/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/service/UserStoreSubscribeService.java
@@ -18,8 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.couponmoa.backend.couponmoastore.common.exception.ErrorCode.DUPLICATED_USER_COUPON;
-import static com.couponmoa.backend.couponmoastore.common.exception.ErrorCode.STORE_NOT_FOUND;
+import static com.couponmoa.backend.couponmoastore.common.exception.ErrorCode.*;
 
 
 @Service
@@ -37,7 +36,7 @@ public class UserStoreSubscribeService {
         Store store = getStore(storeId);
 
         if (userStoreSubRepo.existsByUserIdAndStore(userId, store)) {
-            throw new ApplicationException(DUPLICATED_USER_COUPON);
+            throw new ApplicationException(DUPLICATED_USER_STORE);
         }
 
         UserStoreSubscribe userCouponSubscribe = new UserStoreSubscribe(userId, store);
@@ -79,9 +78,7 @@ public class UserStoreSubscribeService {
 
         SendToMQDto message = new SendToMQDto(
                 emailList,
-                "가게 새 쿠폰 발행 안내",
-                store.getName(),
-                "에서 새 쿠폰이 발행되었습니다!");
+                store.getName());
 
         sqsService.sendMessage(message);
 


### PR DESCRIPTION
# 변경점

## 알림 서버에서의 dto에 맞게 SendToMQDto 클래스의 필드 변경
  ```
  private String storeName;
  private List<String> emailList
  ```
## 메시지 큐 이름 변경에 따라 본 서버에서도 스토어에서 새 쿠폰이 발행되었을 때 스토어 구독자들에게 전달하기위한 MQ 변경
- 본 변경 사항은 깃허브 시크릿에 포함(`APPLICATION_PROD_YML`)
  ```
  couponmoa-queue -> couponmoa-create-queue
  ```