### PR TITLE
Workflows 파일 수정 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,15 +5,20 @@ on:
     branches:
       - dev
 
-permissions:
-  contents: read
-  id-token: write
-
 env:
   AWS_REGION: ap-northeast-2
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   SPRING_PROFILE: prod
+  JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+  REDIS_HOST: ${{ secrets.REDIS_HOST }}
+  RDS_URL: ${{ secrets.RDS_URL }}
+  RDS_USERNAME: ${{ secrets.RDS_USERNAME }}
+  RDS_PASSWORD: ${{ secrets.RDS_PASSWORD }}
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  ECR_REPOSITORY: couponmoa-dev-store-ecr
+  ECS_STORE_TASK_DEFINITION_FAMILY: ${{ secrets.ECS_STORE_TASK_DEFINITION_FAMILY }}
+  ECS_STORE_SERVICE_NAME: ${{ secrets.ECS_STORE_SERVICE_NAME }}
+  ECS_CLUSTER_NAME: ${{ secrets.ECS_CLUSTER_NAME }}
+
 
 jobs:
   deploy:
@@ -30,15 +35,20 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Create application-prod.yml
-        run: |
-          mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION_PROD_YML }}" > src/main/resources/application-prod.yml
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
 
       - name: Grant execute permission to gradlew
         run: chmod +x ./gradlew
 
-      - name: Build with Gradle (after creating yml)
+      - name: Build with Gradle
         run: ./gradlew generateProto build -x test -x asciidoctor
 
       - name: Set up Docker
@@ -52,22 +62,58 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Login to Amazon ECR
-        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build, Tag, and Push Docker image to ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: couponmoa-dev-store-ecr
-          IMAGE_TAG: latest
+        id: build_image
+        shell: bash
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          # 이미지 태그로 커밋 SHA 사용 (coupon workflow 방식)
+          IMAGE_TAG=${{ github.sha }}
+          # env 블록에서 ECR 관련 정보 사용
+          ECR_REGISTRY="${{ steps.login-ecr.outputs.registry }}"
+          ECR_REPOSITORY="${{ env.ECR_REPOSITORY }}"
+          REGION="${{ env.AWS_REGION }}"
 
-      - name: Force new deployment to ECS
+          FULL_IMAGE_TAG="${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}"
+
+          echo "Attempting to build image with tag: ${FULL_IMAGE_TAG}"
+          # Dockerfile이 프로젝트 루트에 있다고 가정
+          # 애플리케이션이 환경 변수에서 설정을 읽도록 구성되어 있어야 합니다.
+          docker build -t "${FULL_IMAGE_TAG}" -f ./Dockerfile .
+
+          echo "built_image_tag=${FULL_IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Push to ECR
+        shell: bash
         run: |
-          aws ecs update-service \
-            --cluster ${{ secrets.ECS_CLUSTER_NAME }} \
-            --service ${{ secrets.ECS_SERVICE_NAME }} \
-            --force-new-deployment \
-            --region ap-northeast-2
+          # build_image 스텝의 출력에서 이미지 태그 가져오기
+          IMAGE_TAG="${{ steps.build_image.outputs.built_image_tag }}"
+          if [ -z "$IMAGE_TAG" ]; then
+            echo "❌ Docker image tag is empty. Build step might have failed."
+            exit 1
+          fi
+          echo "Pushing image: $IMAGE_TAG"
+          docker push "$IMAGE_TAG"
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.ECS_STORE_TASK_DEFINITION_FAMILY }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: couponmoa-dev-store-container
+          image: ${{ steps.build_image.outputs.built_image_tag }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_STORE_SERVICE_NAME }}
+          cluster: ${{ env.ECS_CLUSTER_NAME }}
+          wait-for-service-stability: true

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.google.protobuf' version '0.9.4'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    // common 분리 시 삭제
+    id 'java-test-fixtures'
 }
 
 group = 'com.couponmoa.backend'
@@ -72,9 +74,6 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
-    // H2 test DB
-    testImplementation 'com.h2database:h2'
-
     // Spring Boot Configuration Processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
@@ -103,6 +102,29 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // testContainer - common 나중에 testFixturesImplementation
+    testImplementation 'org.testcontainers:testcontainers'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:junit-jupiter' // JUnit 5 사용 시
+    testImplementation 'org.testcontainers:mysql'
+    testImplementation 'com.mysql:mysql-connector-j'
+
+    // testContainer와 사용되는 Spring Boot 기능을 위해 필요 -common 나중에 testFixturesImplementation
+    testImplementation 'org.springframework:spring-test'
+    testImplementation 'org.springframework.boot:spring-boot-test'
+    testImplementation 'org.springframework.boot:spring-boot-autoconfigure'
+
+    // testFixtures에서 Spring 테스트 기능을 사용하기 위한 의존성 common 나중에
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // testFixtures에서 Testcontainers를 사용하기 위한 의존성 common 나중에
+    testFixturesImplementation 'org.testcontainers:testcontainers'
+    testFixturesImplementation 'org.testcontainers:junit-jupiter'
+    testFixturesImplementation 'org.testcontainers:mysql'
+
+    // common 분리시 삭제 (testContainer)
+    testImplementation testFixtures(project(':'))
 }
 
 protobuf {

--- a/src/test/java/com/couponmoa/backend/couponmoastore/CouponmoaStoreApplicationTests.java
+++ b/src/test/java/com/couponmoa/backend/couponmoastore/CouponmoaStoreApplicationTests.java
@@ -2,6 +2,7 @@ package com.couponmoa.backend.couponmoastore;
 
 import com.couponmoa.backend.couponmoastore.common.emailSender.service.SqsService;
 import com.couponmoa.backend.couponmoastore.domain.store.grpc.UserGrpcClient;
+import com.couponmoa.common.testcontainers.TestContainerBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -9,7 +10,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class CouponmoaStoreApplicationTests {
+class CouponmoaStoreApplicationTests extends TestContainerBase {
 
     @MockitoBean
     private UserGrpcClient userGrpcClient;

--- a/src/test/java/com/couponmoa/backend/couponmoastore/domain/store/controller/v1/StoreControllerTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoastore/domain/store/controller/v1/StoreControllerTest.java
@@ -6,6 +6,7 @@ import com.couponmoa.backend.couponmoastore.domain.store.dto.request.StoreReques
 import com.couponmoa.backend.couponmoastore.domain.store.dto.response.StoreResponseDto;
 import com.couponmoa.backend.couponmoastore.domain.store.dto.response.StoreSimpleResponse;
 import com.couponmoa.backend.couponmoastore.domain.store.service.v1.StoreService;
+import com.couponmoa.common.testcontainers.TestContainerBase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @WebMvcTest(StoreController.class)
 @Import(TestSecurityConfig.class)
-public class StoreControllerTest {
+public class StoreControllerTest extends TestContainerBase {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/controller/UserStoreSubscribeControllerTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/controller/UserStoreSubscribeControllerTest.java
@@ -3,6 +3,7 @@ package com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.controll
 import com.couponmoa.backend.couponmoastore.config.TestSecurityConfig;
 import com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.dto.response.FindStoreSubscribeListResponse;
 import com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.service.UserStoreSubscribeService;
+import com.couponmoa.common.testcontainers.TestContainerBase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureRestDocs
 @WebMvcTest(UserStoreSubscribeController.class)
 @Import(TestSecurityConfig.class)
-public class UserStoreSubscribeControllerTest {
+public class UserStoreSubscribeControllerTest extends TestContainerBase {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/service/UserStoreSubscribeServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoastore/domain/subscribe/userstore/service/UserStoreSubscribeServiceTest.java
@@ -10,6 +10,7 @@ import com.couponmoa.backend.couponmoastore.domain.store.repository.StoreReposit
 import com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.dto.response.FindStoreSubscribeListResponse;
 import com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.entity.UserStoreSubscribe;
 import com.couponmoa.backend.couponmoastore.domain.subscribe.userstore.repository.UserStoreSubscribeRepository;
+import com.couponmoa.common.testcontainers.TestContainerBase;
 import com.couponmoa.grpc.user.UserResponse;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class UserStoreSubscribeServiceTest {
+public class UserStoreSubscribeServiceTest extends TestContainerBase {
 
     @Mock
     private UserGrpcClient userGrpcClient;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,9 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password: ""
-    driver-class-name: org.h2.Driver
   jpa:
     hibernate:
       ddl-auto: update
@@ -11,7 +6,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
 
   data:
     redis:

--- a/src/testFixtures/java/com/couponmoa/common/testcontainers/TestContainerBase.java
+++ b/src/testFixtures/java/com/couponmoa/common/testcontainers/TestContainerBase.java
@@ -1,0 +1,28 @@
+package com.couponmoa.common.testcontainers;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class TestContainerBase { // 나중에 common 라이브러리화
+
+    private static final MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test");
+
+    static {
+        MYSQL_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    static void registerTestDatabaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+        registry.add("spring.jpa.properties.hibernate.dialect", () -> "org.hibernate.dialect.MySQL8Dialect");
+    }
+}


### PR DESCRIPTION
 Docker 이미지 태그 전략 변경
이전: latest 태그 사용
→ 최신 이미지로 자동 업데이트되지만, 어떤 커밋의 이미지가 배포되었는지 명확하지 않음.

변경 후: ${{ github.sha }} (커밋 해시)를 이미지 태그로 사용
→ 배포된 이미지가 어떤 소스 코드 커밋과 일치하는지 명확히 추적 가능.

 Gradle 빌드 캐시 추가
이전: Gradle 종속성 및 래퍼 캐시 부재
→ 매번 모든 의존성을 다시 다운로드해야 했음.

변경 후: actions/cache@v3 액션을 통해 Gradle 캐시 추가
→ 워크플로우 재실행 시 빌드 시간 단축.

 환경 변수 관리 방식 변경
이전: application-prod.yml 파일 내용을 시크릿에서 가져와 파일로 생성.

변경 후: 주요 시크릿 값(JWT, RDS, Redis 등)을 env 블록에 선언하고,
애플리케이션이 실행 시 환경 변수에서 값을 읽도록 수정.
→ application-prod.yml 파일 내에서는 ${환경변수명} 형태로 참조해야 함.

 AWS 인증 방식 명확화
이전: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY를 env 블록에 선언
→ 전체 워크플로우에 노출될 위험.

변경 후: aws-actions/configure-aws-credentials@v2 액션 사용
→ 자격 증명을 시크릿에서 불러오고, 해당 스텝 범위 내에서만 사용되도록 설정.
→ 보안 강화.

 Docker BuildX 설정 추가
이전: docker/setup-buildx-action@v3 미사용 또는 다른 방식으로 설정.

변경 후: docker/setup-buildx-action@v3 액션 추가
→ 최신 Docker 빌드 기능을 사용할 수 있는 환경 구성.